### PR TITLE
fix(ipamd): donot allow borrowing across subnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # The building args, they will be injected into binary file.
-CNI_VERSION=1.0.0-beta1
+CNI_VERSION=1.0.0-beta2
 WORKDIR=$(shell pwd)
 PKG_VERSION_PATH="github.com/ucloud/uk8s-cni-vpc/pkg/version"
 GO_VERSION=$(shell go version)

--- a/cmd/cnivpc/rpc.go
+++ b/cmd/cnivpc/rpc.go
@@ -140,7 +140,7 @@ func allocateSecondaryIP(podName, podNS, sandboxID string) (*rpc.PodNetwork, err
 		return nil, err
 	}
 
-	uApi, err := uapi.NewApiClient()
+	uApi, err := uapi.NewClient()
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func allocateSecondaryIP(podName, podNS, sandboxID string) (*rpc.PodNetwork, err
 }
 
 func checkSecondaryIPExist(ip, mac string) (bool, error) {
-	uApi, err := uapi.NewApiClient()
+	uApi, err := uapi.NewClient()
 	if err != nil {
 		return false, err
 	}
@@ -219,7 +219,7 @@ func instanceType(resource string) string {
 }
 
 func getObjectIDforSecondaryIP() (string, error) {
-	uApi, err := uapi.NewApiClient()
+	uApi, err := uapi.NewClient()
 	if err != nil {
 		return "", err
 	}
@@ -267,7 +267,7 @@ func deallocateSecondaryIP(podName, podNS, podInfraContainerID string, pNet *rpc
 	}
 
 	// Create UCloud api client config
-	uApi, err := uapi.NewApiClient()
+	uApi, err := uapi.NewClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/ipamctl/status.go
+++ b/cmd/ipamctl/status.go
@@ -27,7 +27,7 @@ var Status = &cobra.Command{
 			return nil
 		}
 
-		lines := []string{"NAME | SIZE | STATUS"}
+		lines := []string{"NAME | SUBNET | SIZE | STATUS"}
 		for _, ipamd := range ipamdList.Items {
 			var attr color.Attribute
 			switch ipamd.Status.Status {
@@ -45,7 +45,8 @@ var Status = &cobra.Command{
 			}
 
 			c := color.New(attr)
-			line := fmt.Sprintf("%s | %d | %s", ipamd.Name, ipamd.Status.Current,
+			line := fmt.Sprintf("%s | %s | %d | %s", ipamd.Name,
+				ipamd.Spec.Subnet, ipamd.Status.Current,
 				c.Sprint(ipamd.Status.Status))
 			lines = append(lines, line)
 		}

--- a/cmd/vip-controller/main.go
+++ b/cmd/vip-controller/main.go
@@ -149,7 +149,7 @@ func vipCheckAndClean() {
 }
 
 func releaseVPCIp(vpcip v1beta1.VpcIpClaim) error {
-	uApi, err := uapi.NewApiClient()
+	uApi, err := uapi.NewClient()
 	if err != nil {
 		return nil
 	}

--- a/deploy/ipamd.yaml
+++ b/deploy/ipamd.yaml
@@ -68,7 +68,7 @@ spec:
       hostPID: true
       containers:
         - name: cni-vpc-ipamd
-          image: uhub.service.ucloud.cn/wxyz/cni-vpc-ipamd:build-f07494c
+          image: uhub.service.ucloud.cn/uk8s/cni-vpc-ipamd:1.0.0-beta2
           resources:
             limits:
               cpu: 200m

--- a/deploy/ipamd.yaml
+++ b/deploy/ipamd.yaml
@@ -68,7 +68,7 @@ spec:
       hostPID: true
       containers:
         - name: cni-vpc-ipamd
-          image: uhub.service.ucloud.cn/uk8s/cni-vpc-ipamd:0.1.0-rc1
+          image: uhub.service.ucloud.cn/wxyz/cni-vpc-ipamd:build-f07494c
           resources:
             limits:
               cpu: 200m
@@ -157,6 +157,8 @@ spec:
                 node:
                   type: string
                 addr:
+                  type: string
+                subnet:
                   type: string
             status:
               type: object

--- a/kubernetes/apis/ipamd/v1beta1/types.go
+++ b/kubernetes/apis/ipamd/v1beta1/types.go
@@ -38,8 +38,9 @@ type Ipamd struct {
 
 // IpamdSpec is the spec for a Ipamd resource
 type IpamdSpec struct {
-	Node string `json:"node"`
-	Addr string `json:"addr"`
+	Node   string `json:"node"`
+	Addr   string `json:"addr"`
+	Subnet string `json:"subnet"`
 }
 
 // IpamdSpec is the status for Ipamd resource

--- a/pkg/ipamd/svc.go
+++ b/pkg/ipamd/svc.go
@@ -24,6 +24,7 @@ import (
 	crdclientset "github.com/ucloud/uk8s-cni-vpc/kubernetes/generated/clientset/versioned"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/kubeclient"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/storage"
+	"github.com/ucloud/uk8s-cni-vpc/pkg/uapi"
 	"github.com/ucloud/uk8s-cni-vpc/rpc"
 
 	"github.com/boltdb/bolt"
@@ -73,6 +74,8 @@ type ipamServer struct {
 
 	// The tcp address to listen
 	tcpAddr string
+
+	uapi *uapi.ApiClient
 }
 
 func IpamdServer() error {
@@ -85,10 +88,17 @@ func IpamdServer() error {
 		return err
 	}
 
+	uapiClient, err := uapi.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to init uapi client: %v", err)
+	}
+
 	server := grpc.NewServer()
 	ipd := &ipamServer{
 		kubeClient: kubeClient,
 		crdClient:  crdClient,
+
+		uapi: uapiClient,
 
 		nodeName: os.Getenv("KUBE_NODE_NAME"),
 	}

--- a/pkg/uapi/client.go
+++ b/pkg/uapi/client.go
@@ -82,7 +82,7 @@ func LocalRegion() string {
 	}
 }
 
-func NewApiClient() (*ApiClient, error) {
+func NewClient() (*ApiClient, error) {
 	self, err := getMyself()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get uapi metadata information, %v", err)


### PR DESCRIPTION
When the IP is borrowed across subnets, calling the [MoveSecondaryIPMac](https://docs.ucloud.cn/api/vpc2.0-api/move_secondary_ip_mac) api will fail. Because the Mac address does not exist in the opposite subnet.

Therefore, we need to record the subnet id of the current node in CR, and cross-subnet borrowing is not allowed.