### PR TITLE
feat: support uphost 

### DIFF
--- a/pkg/ipamd/svc.go
+++ b/pkg/ipamd/svc.go
@@ -37,7 +37,7 @@ import (
 const (
 	IpamdServiceSocket    = "/run/cni-vpc-ipamd.sock"
 	UHostMasterInterface  = "eth0"
-	UPHostMasterInterface = "net1"
+	UPHostMasterInterface = "eth2" // BM.Compute.A2.M10
 	CNIVpcDbName          = "cni-vpc-network"
 	CNIVPCIpPoolDBName    = "cni-vpc-ip-pool"
 	DefaultListenTCPPort  = 7312

--- a/pkg/ipamd/util.go
+++ b/pkg/ipamd/util.go
@@ -72,7 +72,11 @@ func getMasterInterface() string {
 		return UHostMasterInterface
 	}
 
-	uapiClient, _ := uapi.NewClient()
+	uapiClient, err := uapi.NewClient()
+	if err != nil {
+		klog.Errorf("failed to init uapi client: %v", err)
+		return UHostMasterInterface
+	}
 	resource := uapiClient.InstanceID()
 	if strings.HasPrefix(resource, "upm-") {
 		for _, iface := range list {

--- a/pkg/ipamd/util.go
+++ b/pkg/ipamd/util.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ucloud/uk8s-cni-vpc/pkg/uapi"
 	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 )
@@ -71,9 +72,13 @@ func getMasterInterface() string {
 		return UHostMasterInterface
 	}
 
-	for _, iface := range list {
-		if iface.Name == UPHostMasterInterface {
-			return UPHostMasterInterface
+	uapiClient, _ := uapi.NewClient()
+	resource := uapiClient.InstanceID()
+	if strings.HasPrefix(resource, "upm-") {
+		for _, iface := range list {
+			if iface.Name == UPHostMasterInterface {
+				return UPHostMasterInterface
+			}
 		}
 	}
 	return UHostMasterInterface


### PR DESCRIPTION
1.  云主机和裸金属I7.M10的IP地址都在网卡eth0上，而裸金属A2.M10的IP地址在网卡eth2上
2. 只有云主机和A2.M10有eth2
云主机
![image](https://user-images.githubusercontent.com/22639464/225558079-8da0ff14-1530-4318-b174-0528296dc5b5.png)
裸金属A2.M10
![image](https://user-images.githubusercontent.com/22639464/225558106-a2fc4601-bafd-4e09-a676-a004cc49cffb.png)
裸金属I7.M10
![image](https://user-images.githubusercontent.com/22639464/225823755-fa53828b-beec-4b6d-ac57-3ccf0dd4ebc5.png)

