### PR TITLE
Feat/action cni init

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       with:
         go-version: 1.24.5
 
+    - name: Build cnivpc-init
+      run: DEPLOY=true make push-cnivpc-init-image
+
     - name: Build cnivpc
       run: DEPLOY=true make cnivpc
 


### PR DESCRIPTION
- Introduced a new job in the release workflow to build and push the cnivpc-init Docker image.
- This addition ensures that the cnivpc-init component is included in the deployment process.

Rationale:
- Enhances the release workflow by automating the build process for the cnivpc-init image, improving deployment efficiency.