### PR TITLE
实现 NAT outgoing IP management

### DIFF
--- a/cmd/cnivpc/if.go
+++ b/cmd/cnivpc/if.go
@@ -352,7 +352,7 @@ func newIptablesRulesManager(primaryIP, primaryInterface string) (*iptablesRules
 	}, nil
 }
 
-func (m *iptablesRulesManager) updateRules() error {
+func (m *iptablesRulesManager) updateRules(nodeName string) error {
 	if err := ensureNATGWOutgoingIPSet(); err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func (m *iptablesRulesManager) updateRules() error {
 		return err
 	}
 	if needsMigration {
-		if err := migrateLegacyNATGWOutgoingIPs(); err != nil {
+		if err := migrateLegacyNATGWOutgoingIPs(nodeName); err != nil {
 			return err
 		}
 	}
@@ -422,19 +422,7 @@ func (m *iptablesRulesManager) needsNATGWOutgoingMigration() (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATGWOutgoingMigration check bypass rule")
 	}
-	if bypassExists {
-		return false, nil
-	}
-
-	jumpExists, err := m.ipt.Exists("nat", "PREROUTING", podOutboundConnmarkJumpRule()...)
-	if err != nil {
-		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATGWOutgoingMigration check jump rule")
-	}
-	markExists, err := m.ipt.Exists("nat", connmarkChainName, podOutboundConnmarkRule()...)
-	if err != nil {
-		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATGWOutgoingMigration check mark rule")
-	}
-	return !jumpExists || !markExists, nil
+	return !bypassExists, nil
 }
 
 func (m *iptablesRulesManager) buildSNATRules() ([]iptablesRule, error) {

--- a/cmd/cnivpc/if.go
+++ b/cmd/cnivpc/if.go
@@ -396,7 +396,6 @@ func podOutboundConnmarkJumpRule() []string {
 
 func natOutgoingBypassRule() []string {
 	return []string{
-		"!", "-d", metadataServiceCIDR,
 		"-m", "set", "--match-set", natOutgoingDisabledIPSetName, "src",
 		"-m", "comment", "--comment", "UCLOUD NAT OUTGOING DISABLED",
 		"-j", "RETURN",
@@ -531,8 +530,7 @@ func (m *iptablesRulesManager) buildConnmarkRules() ([]iptablesRule, error) {
 	}
 
 	// Pods with NAT outgoing disabled must retain their source address and use
-	// the existing source-based UNI route. Metadata traffic is kept on the
-	// primary interface for backward compatibility.
+	// the existing source-based UNI route.
 	rules = append(rules, iptablesRule{
 		name:        connmarkChainName,
 		shouldExist: true,

--- a/cmd/cnivpc/if.go
+++ b/cmd/cnivpc/if.go
@@ -22,6 +22,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/cockroachdb/errors"
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/iputils"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/ulog"
@@ -352,6 +353,19 @@ func newIptablesRulesManager(primaryIP, primaryInterface string) (*iptablesRules
 }
 
 func (m *iptablesRulesManager) updateRules() error {
+	if err := ensureNATOutgoingIPSet(); err != nil {
+		return err
+	}
+	needsMigration, err := m.needsNATOutgoingMigration()
+	if err != nil {
+		return err
+	}
+	if needsMigration {
+		if err := migrateLegacyNATOutgoingIPs(); err != nil {
+			return err
+		}
+	}
+
 	snatRules, err := m.buildSNATRules()
 	if err != nil {
 		return err
@@ -371,6 +385,57 @@ func (m *iptablesRulesManager) updateRules() error {
 	}
 
 	return nil
+}
+
+func podOutboundConnmarkJumpRule() []string {
+	return []string{
+		"-i", "ucni+", "-m", "comment", "--comment", "UCLOUD outbound connections",
+		"-m", "state", "--state", "NEW", "-j", connmarkChainName,
+	}
+}
+
+func natOutgoingBypassRule() []string {
+	return []string{
+		"!", "-d", metadataServiceCIDR,
+		"-m", "set", "--match-set", natOutgoingDisabledIPSetName, "src",
+		"-m", "comment", "--comment", "UCLOUD NAT OUTGOING DISABLED",
+		"-j", "RETURN",
+	}
+}
+
+func podOutboundConnmarkRule() []string {
+	return []string{
+		"-m", "comment", "--comment", "UCLOUD CONNMARK", "-j", "CONNMARK",
+		"--set-xmark", fmt.Sprintf("%#x/%#x", defaultConnmark, defaultConnmark),
+	}
+}
+
+func (m *iptablesRulesManager) needsNATOutgoingMigration() (bool, error) {
+	chainExists, err := m.ipt.ChainExists("nat", connmarkChainName)
+	if err != nil {
+		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATOutgoingMigration check chain")
+	}
+	if !chainExists {
+		return true, nil
+	}
+
+	bypassExists, err := m.ipt.Exists("nat", connmarkChainName, natOutgoingBypassRule()...)
+	if err != nil {
+		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATOutgoingMigration check bypass rule")
+	}
+	if bypassExists {
+		return false, nil
+	}
+
+	jumpExists, err := m.ipt.Exists("nat", "PREROUTING", podOutboundConnmarkJumpRule()...)
+	if err != nil {
+		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATOutgoingMigration check jump rule")
+	}
+	markExists, err := m.ipt.Exists("nat", connmarkChainName, podOutboundConnmarkRule()...)
+	if err != nil {
+		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATOutgoingMigration check mark rule")
+	}
+	return !jumpExists || !markExists, nil
 }
 
 func (m *iptablesRulesManager) buildSNATRules() ([]iptablesRule, error) {
@@ -453,23 +518,6 @@ func (m *iptablesRulesManager) buildConnmarkRules() ([]iptablesRule, error) {
 
 	rules := make([]iptablesRule, 0)
 
-	rule := iptablesRule{
-		name:        "connmark rule for non-VPC outbound traffic",
-		shouldExist: true,
-		table:       "nat",
-		chain:       "PREROUTING",
-		rule: []string{
-			"-i", "ucni+", "-m", "comment", "--comment", "UCLOUD outbound connections",
-			"-m", "state", "--state", "NEW", "-j", connmarkChainName,
-		},
-	}
-	// Force delete legacy rule: the rule was matching on "-m state --state NEW", which is
-	// always true for packets traversing the nat table
-	deleteRule := rule
-	deleteRule.shouldExist = false
-	rules = append(rules, deleteRule)
-	rules = append(rules, rule)
-
 	for _, cidr := range m.vpcCIDRs {
 		rules = append(rules, iptablesRule{
 			name:        connmarkChainName,
@@ -482,16 +530,40 @@ func (m *iptablesRulesManager) buildConnmarkRules() ([]iptablesRule, error) {
 		})
 	}
 
+	// Pods with NAT outgoing disabled must retain their source address and use
+	// the existing source-based UNI route. Metadata traffic is kept on the
+	// primary interface for backward compatibility.
+	rules = append(rules, iptablesRule{
+		name:        connmarkChainName,
+		shouldExist: true,
+		table:       "nat",
+		chain:       connmarkChainName,
+		rule:        natOutgoingBypassRule(),
+	})
+
 	rules = append(rules, iptablesRule{
 		name:        "connmark rule for external outbound traffic",
 		shouldExist: true,
 		table:       "nat",
 		chain:       connmarkChainName,
-		rule: []string{
-			"-m", "comment", "--comment", "UCLOUD CONNMARK", "-j", "CONNMARK",
-			"--set-xmark", fmt.Sprintf("%#x/%#x", defaultConnmark, defaultConnmark),
-		},
+		rule:        podOutboundConnmarkRule(),
 	})
+
+	// Attach the custom chain only after its bypass rules are ready, so legacy
+	// Pod traffic cannot reach an existing mark rule during migration.
+	rule := iptablesRule{
+		name:        "connmark rule for non-VPC outbound traffic",
+		shouldExist: true,
+		table:       "nat",
+		chain:       "PREROUTING",
+		rule:        podOutboundConnmarkJumpRule(),
+	}
+	// Force delete legacy rule: the rule was matching on "-m state --state NEW", which is
+	// always true for packets traversing the nat table
+	deleteRule := rule
+	deleteRule.shouldExist = false
+	rules = append(rules, deleteRule)
+	rules = append(rules, rule)
 
 	// Being in the nat table, this only applies to the first packet of the connection. The mark
 	// will be restored in the mangle table for subsequent packets.

--- a/cmd/cnivpc/if.go
+++ b/cmd/cnivpc/if.go
@@ -352,20 +352,7 @@ func newIptablesRulesManager(primaryIP, primaryInterface string) (*iptablesRules
 	}, nil
 }
 
-func (m *iptablesRulesManager) updateRules(nodeName string) error {
-	if err := ensureNATGWOutgoingIPSet(); err != nil {
-		return err
-	}
-	needsMigration, err := m.needsNATGWOutgoingMigration()
-	if err != nil {
-		return err
-	}
-	if needsMigration {
-		if err := migrateLegacyNATGWOutgoingIPs(nodeName); err != nil {
-			return err
-		}
-	}
-
+func (m *iptablesRulesManager) updateRules(nodeName string, natGWOutgoingEnabled bool) error {
 	snatRules, err := m.buildSNATRules()
 	if err != nil {
 		return err
@@ -384,7 +371,43 @@ func (m *iptablesRulesManager) updateRules(nodeName string) error {
 		return err
 	}
 
+	if natGWOutgoingEnabled {
+		if err := m.tryEnableNATGWOutgoing(nodeName); err != nil {
+			ulog.Warnf("Enable NAT gateway outgoing failed, fallback to node SNAT: %+v", err)
+		}
+	}
+
 	return nil
+}
+
+func (m *iptablesRulesManager) tryEnableNATGWOutgoing(nodeName string) error {
+	if err := ensureNATGWOutgoingIPSet(); err != nil {
+		return err
+	}
+
+	needsMigration, err := m.needsNATGWOutgoingMigration()
+	if err != nil {
+		return err
+	}
+	if !needsMigration {
+		return nil
+	}
+
+	// Keep the bypass rule absent when migration fails. Existing Pods then
+	// retain node SNAT, and the next enabled CNI ADD retries the migration.
+	if err := migrateLegacyNATGWOutgoingIPs(nodeName); err != nil {
+		return err
+	}
+
+	return updateIptablesRules([]iptablesRule{
+		{
+			name:        connmarkChainName,
+			shouldExist: true,
+			table:       "nat",
+			chain:       connmarkChainName,
+			rule:        natGWOutgoingBypassRule(),
+		},
+	}, m.ipt)
 }
 
 func podOutboundConnmarkJumpRule() []string {
@@ -516,16 +539,6 @@ func (m *iptablesRulesManager) buildConnmarkRules() ([]iptablesRule, error) {
 			},
 		})
 	}
-
-	// Pods using NAT gateway outgoing must retain their source address and use
-	// the existing source-based UNI route instead of node SNAT.
-	rules = append(rules, iptablesRule{
-		name:        connmarkChainName,
-		shouldExist: true,
-		table:       "nat",
-		chain:       connmarkChainName,
-		rule:        natGWOutgoingBypassRule(),
-	})
 
 	rules = append(rules, iptablesRule{
 		name:        "connmark rule for external outbound traffic",

--- a/cmd/cnivpc/if.go
+++ b/cmd/cnivpc/if.go
@@ -422,7 +422,7 @@ func podOutboundConnmarkJumpRule() []string {
 func natGWOutgoingBypassRule() []string {
 	return []string{
 		"-m", "set", "--match-set", natGWOutgoingEnabledIPSetName, "src",
-		"-m", "comment", "--comment", "UCLOUD NAT OUTGOING DISABLED",
+		"-m", "comment", "--comment", "UCLOUD NATGW OUTGOING DISABLED",
 		"-j", "RETURN",
 	}
 }

--- a/cmd/cnivpc/if.go
+++ b/cmd/cnivpc/if.go
@@ -353,15 +353,15 @@ func newIptablesRulesManager(primaryIP, primaryInterface string) (*iptablesRules
 }
 
 func (m *iptablesRulesManager) updateRules() error {
-	if err := ensureNATOutgoingIPSet(); err != nil {
+	if err := ensureNATGWOutgoingIPSet(); err != nil {
 		return err
 	}
-	needsMigration, err := m.needsNATOutgoingMigration()
+	needsMigration, err := m.needsNATGWOutgoingMigration()
 	if err != nil {
 		return err
 	}
 	if needsMigration {
-		if err := migrateLegacyNATOutgoingIPs(); err != nil {
+		if err := migrateLegacyNATGWOutgoingIPs(); err != nil {
 			return err
 		}
 	}
@@ -394,9 +394,9 @@ func podOutboundConnmarkJumpRule() []string {
 	}
 }
 
-func natOutgoingBypassRule() []string {
+func natGWOutgoingBypassRule() []string {
 	return []string{
-		"-m", "set", "--match-set", natOutgoingDisabledIPSetName, "src",
+		"-m", "set", "--match-set", natGWOutgoingEnabledIPSetName, "src",
 		"-m", "comment", "--comment", "UCLOUD NAT OUTGOING DISABLED",
 		"-j", "RETURN",
 	}
@@ -409,18 +409,18 @@ func podOutboundConnmarkRule() []string {
 	}
 }
 
-func (m *iptablesRulesManager) needsNATOutgoingMigration() (bool, error) {
+func (m *iptablesRulesManager) needsNATGWOutgoingMigration() (bool, error) {
 	chainExists, err := m.ipt.ChainExists("nat", connmarkChainName)
 	if err != nil {
-		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATOutgoingMigration check chain")
+		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATGWOutgoingMigration check chain")
 	}
 	if !chainExists {
 		return true, nil
 	}
 
-	bypassExists, err := m.ipt.Exists("nat", connmarkChainName, natOutgoingBypassRule()...)
+	bypassExists, err := m.ipt.Exists("nat", connmarkChainName, natGWOutgoingBypassRule()...)
 	if err != nil {
-		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATOutgoingMigration check bypass rule")
+		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATGWOutgoingMigration check bypass rule")
 	}
 	if bypassExists {
 		return false, nil
@@ -428,11 +428,11 @@ func (m *iptablesRulesManager) needsNATOutgoingMigration() (bool, error) {
 
 	jumpExists, err := m.ipt.Exists("nat", "PREROUTING", podOutboundConnmarkJumpRule()...)
 	if err != nil {
-		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATOutgoingMigration check jump rule")
+		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATGWOutgoingMigration check jump rule")
 	}
 	markExists, err := m.ipt.Exists("nat", connmarkChainName, podOutboundConnmarkRule()...)
 	if err != nil {
-		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATOutgoingMigration check mark rule")
+		return false, errors.Wrap(err, "main.iptablesRulesManager.needsNATGWOutgoingMigration check mark rule")
 	}
 	return !jumpExists || !markExists, nil
 }
@@ -529,14 +529,14 @@ func (m *iptablesRulesManager) buildConnmarkRules() ([]iptablesRule, error) {
 		})
 	}
 
-	// Pods with NAT outgoing disabled must retain their source address and use
-	// the existing source-based UNI route.
+	// Pods using NAT gateway outgoing must retain their source address and use
+	// the existing source-based UNI route instead of node SNAT.
 	rules = append(rules, iptablesRule{
 		name:        connmarkChainName,
 		shouldExist: true,
 		table:       "nat",
 		chain:       connmarkChainName,
-		rule:        natOutgoingBypassRule(),
+		rule:        natGWOutgoingBypassRule(),
 	})
 
 	rules = append(rules, iptablesRule{

--- a/cmd/cnivpc/if.go
+++ b/cmd/cnivpc/if.go
@@ -422,7 +422,7 @@ func podOutboundConnmarkJumpRule() []string {
 func natGWOutgoingBypassRule() []string {
 	return []string{
 		"-m", "set", "--match-set", natGWOutgoingEnabledIPSetName, "src",
-		"-m", "comment", "--comment", "UCLOUD NATGW OUTGOING DISABLED",
+		"-m", "comment", "--comment", "UCLOUD NATGW OUTGOING ENABLED",
 		"-j", "RETURN",
 	}
 }

--- a/cmd/cnivpc/if.go
+++ b/cmd/cnivpc/if.go
@@ -377,7 +377,9 @@ func (m *iptablesRulesManager) updateRules(nodeName string, natGWOutgoingEnabled
 		}
 	}
 
-	return nil
+	// Attach the custom chain only after its rules and the optional NAT gateway
+	// outgoing migration are ready.
+	return updateIptablesRules(buildConnmarkPreroutingRules(), m.ipt)
 }
 
 func (m *iptablesRulesManager) tryEnableNATGWOutgoing(nodeName string) error {
@@ -429,6 +431,43 @@ func podOutboundConnmarkRule() []string {
 	return []string{
 		"-m", "comment", "--comment", "UCLOUD CONNMARK", "-j", "CONNMARK",
 		"--set-xmark", fmt.Sprintf("%#x/%#x", defaultConnmark, defaultConnmark),
+	}
+}
+
+func buildConnmarkPreroutingRules() []iptablesRule {
+	jumpRule := iptablesRule{
+		name:        "connmark rule for non-VPC outbound traffic",
+		shouldExist: true,
+		table:       "nat",
+		chain:       "PREROUTING",
+		rule:        podOutboundConnmarkJumpRule(),
+	}
+	// Reappend the existing jump rule so the custom chain is attached at the end
+	// of the update.
+	deleteJumpRule := jumpRule
+	deleteJumpRule.shouldExist = false
+
+	// Being in the nat table, this only applies to the first packet of the
+	// connection. It must follow the jump so the connection mark set by the
+	// custom chain is copied to the packet mark before routing.
+	restoreRule := iptablesRule{
+		name:        "connmark to fwmark copy",
+		shouldExist: true,
+		table:       "nat",
+		chain:       "PREROUTING",
+		rule: []string{
+			"-m", "comment", "--comment", "UCLOUD CONNMARK", "-j", "CONNMARK",
+			"--restore-mark", "--mask", fmt.Sprintf("%#x", defaultConnmark),
+		},
+	}
+	deleteRestoreRule := restoreRule
+	deleteRestoreRule.shouldExist = false
+
+	return []iptablesRule{
+		deleteJumpRule,
+		jumpRule,
+		deleteRestoreRule,
+		restoreRule,
 	}
 }
 
@@ -547,40 +586,6 @@ func (m *iptablesRulesManager) buildConnmarkRules() ([]iptablesRule, error) {
 		chain:       connmarkChainName,
 		rule:        podOutboundConnmarkRule(),
 	})
-
-	// Attach the custom chain only after its bypass rules are ready, so legacy
-	// Pod traffic cannot reach an existing mark rule during migration.
-	rule := iptablesRule{
-		name:        "connmark rule for non-VPC outbound traffic",
-		shouldExist: true,
-		table:       "nat",
-		chain:       "PREROUTING",
-		rule:        podOutboundConnmarkJumpRule(),
-	}
-	// Force delete legacy rule: the rule was matching on "-m state --state NEW", which is
-	// always true for packets traversing the nat table
-	deleteRule := rule
-	deleteRule.shouldExist = false
-	rules = append(rules, deleteRule)
-	rules = append(rules, rule)
-
-	// Being in the nat table, this only applies to the first packet of the connection. The mark
-	// will be restored in the mangle table for subsequent packets.
-	rule = iptablesRule{
-		name:        "connmark to fwmark copy",
-		shouldExist: true,
-		table:       "nat",
-		chain:       "PREROUTING",
-		rule: []string{
-			"-m", "comment", "--comment", "UCLOUD CONNMARK", "-j", "CONNMARK",
-			"--restore-mark", "--mask", fmt.Sprintf("%#x", defaultConnmark),
-		},
-	}
-	// Force delete existing restore mark rule so that the subsequent rule gets added to the end
-	deleteRule = rule
-	deleteRule.shouldExist = false
-	rules = append(rules, deleteRule)
-	rules = append(rules, rule)
 
 	return rules, nil
 }

--- a/cmd/cnivpc/main.go
+++ b/cmd/cnivpc/main.go
@@ -262,7 +262,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	if pn != nil && len(pn.VPCIP) > 0 {
 		ulog.Infof("Pod network info %+v", pn)
 		if err = deleteNATGWOutgoingIP(pn.VPCIP); err != nil {
-			return err
+			ulog.Warnf("Delete NAT gateway outgoing IP %s error: %v", pn.VPCIP, err)
 		}
 		if err = cleanUpIPRoutePolicy(pn.VPCIP); err != nil {
 			return fmt.Errorf("fail to clean up ip rules: %v", err)

--- a/cmd/cnivpc/main.go
+++ b/cmd/cnivpc/main.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/ucloud/uk8s-cni-vpc/config"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/arping"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/iputils"
@@ -75,7 +76,7 @@ func cmdArgsString(args *skel.CmdArgs) string {
 }
 
 // cmdAdd is called for ADD requests
-func cmdAdd(args *skel.CmdArgs) error {
+func cmdAdd(args *skel.CmdArgs) (retErr error) {
 	releaseLock := lockfile.MustAcquire()
 	defer releaseLock()
 
@@ -93,13 +94,35 @@ func cmdAdd(args *skel.CmdArgs) error {
 	netNS := os.Getenv("CNI_NETNS")
 
 	// To assign a VPC IP for pod
-	pn, fromIpam, err := assignPodIp(podName, podNS, netNS, sandBoxId)
+	assignment, err := assignPodIp(podName, podNS, netNS, sandBoxId)
 	if err != nil {
 		ulog.Errorf("Assign a vpc ip for pod %s/%s error: %v", podName, podNS, err)
 		return fmt.Errorf("failed to assign ip: %v", err)
 	}
+	pn := assignment.network
+	fromIpam := assignment.fromIPAMD
+
+	var natOutgoingIPAdded bool
+	rollbackNATOutgoingIP := func() error {
+		if !natOutgoingIPAdded {
+			return nil
+		}
+		if cleanupErr := deleteNATOutgoingIP(pn.VPCIP); cleanupErr != nil {
+			return cleanupErr
+		}
+		natOutgoingIPAdded = false
+		return nil
+	}
+	defer func() {
+		if retErr != nil {
+			retErr = errors.CombineErrors(retErr, rollbackNATOutgoingIP())
+		}
+	}()
 
 	rollbackReleaseIP := func() {
+		if cleanupErr := rollbackNATOutgoingIP(); cleanupErr != nil {
+			ulog.Errorf("Rollback NAT outgoing state for IP %s error: %+v", pn.VPCIP, cleanupErr)
+		}
 		err = releasePodIp(podName, podNS, sandBoxId, pn)
 		if err != nil {
 			ulog.Errorf("Release ip %s after failure error: %v, ip might leak", pn.VPCIP, err)
@@ -143,6 +166,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 			rollbackReleaseIP()
 			return ErrIPConflict
 		}
+	}
+
+	natOutgoingIPAdded, err = syncNATOutgoingIP(pn.VPCIP, assignment.natOutgoing)
+	if err != nil {
+		syncErr := err
+		ulog.Errorf("Sync NAT outgoing state for IP %s error: %+v", pn.VPCIP, err)
+		rollbackReleaseIP()
+		return syncErr
 	}
 
 	// We need to setup vethpair to pod's network namespace
@@ -230,6 +261,9 @@ func cmdDel(args *skel.CmdArgs) error {
 	// podIP may be deleted in previous CNI DEL action
 	if pn != nil && len(pn.VPCIP) > 0 {
 		ulog.Infof("Pod network info %+v", pn)
+		if err = deleteNATOutgoingIP(pn.VPCIP); err != nil {
+			return err
+		}
 		if err = cleanUpIPRoutePolicy(pn.VPCIP); err != nil {
 			return fmt.Errorf("fail to clean up ip rules: %v", err)
 		}

--- a/cmd/cnivpc/main.go
+++ b/cmd/cnivpc/main.go
@@ -121,7 +121,7 @@ func cmdAdd(args *skel.CmdArgs) (retErr error) {
 
 	rollbackReleaseIP := func() {
 		if cleanupErr := rollbackNATGWOutgoingIP(); cleanupErr != nil {
-			ulog.Errorf("Rollback NAT gateway outgoing state for IP %s error: %+v", pn.VPCIP, cleanupErr)
+			ulog.Warnf("Rollback NAT gateway outgoing state for IP %s error: %+v", pn.VPCIP, cleanupErr)
 		}
 		err = releasePodIp(podName, podNS, sandBoxId, pn)
 		if err != nil {
@@ -168,12 +168,14 @@ func cmdAdd(args *skel.CmdArgs) (retErr error) {
 		}
 	}
 
-	natGWOutgoingIPAdded, err = syncNATGWOutgoingIP(pn.VPCIP, assignment.natGWOutgoingEnabled)
-	if err != nil {
-		syncErr := err
-		ulog.Errorf("Sync NAT gateway outgoing state for IP %s error: %+v", pn.VPCIP, err)
-		rollbackReleaseIP()
-		return syncErr
+	natGWOutgoingIPAdded, natErr := syncNATGWOutgoingIP(pn.VPCIP, assignment.natGWOutgoingEnabled)
+	if natErr != nil {
+		natGWOutgoingIPAdded = false
+		ulog.Warnf(
+			"Sync NAT gateway outgoing state for IP %s failed, fallback to node SNAT: %+v",
+			pn.VPCIP,
+			natErr,
+		)
 	}
 
 	// We need to setup vethpair to pod's network namespace

--- a/cmd/cnivpc/main.go
+++ b/cmd/cnivpc/main.go
@@ -102,26 +102,26 @@ func cmdAdd(args *skel.CmdArgs) (retErr error) {
 	pn := assignment.network
 	fromIpam := assignment.fromIPAMD
 
-	var natOutgoingIPAdded bool
-	rollbackNATOutgoingIP := func() error {
-		if !natOutgoingIPAdded {
+	var natGWOutgoingIPAdded bool
+	rollbackNATGWOutgoingIP := func() error {
+		if !natGWOutgoingIPAdded {
 			return nil
 		}
-		if cleanupErr := deleteNATOutgoingIP(pn.VPCIP); cleanupErr != nil {
+		if cleanupErr := deleteNATGWOutgoingIP(pn.VPCIP); cleanupErr != nil {
 			return cleanupErr
 		}
-		natOutgoingIPAdded = false
+		natGWOutgoingIPAdded = false
 		return nil
 	}
 	defer func() {
 		if retErr != nil {
-			retErr = errors.CombineErrors(retErr, rollbackNATOutgoingIP())
+			retErr = errors.CombineErrors(retErr, rollbackNATGWOutgoingIP())
 		}
 	}()
 
 	rollbackReleaseIP := func() {
-		if cleanupErr := rollbackNATOutgoingIP(); cleanupErr != nil {
-			ulog.Errorf("Rollback NAT outgoing state for IP %s error: %+v", pn.VPCIP, cleanupErr)
+		if cleanupErr := rollbackNATGWOutgoingIP(); cleanupErr != nil {
+			ulog.Errorf("Rollback NAT gateway outgoing state for IP %s error: %+v", pn.VPCIP, cleanupErr)
 		}
 		err = releasePodIp(podName, podNS, sandBoxId, pn)
 		if err != nil {
@@ -168,10 +168,10 @@ func cmdAdd(args *skel.CmdArgs) (retErr error) {
 		}
 	}
 
-	natOutgoingIPAdded, err = syncNATOutgoingIP(pn.VPCIP, assignment.natOutgoing)
+	natGWOutgoingIPAdded, err = syncNATGWOutgoingIP(pn.VPCIP, assignment.natGWOutgoingEnabled)
 	if err != nil {
 		syncErr := err
-		ulog.Errorf("Sync NAT outgoing state for IP %s error: %+v", pn.VPCIP, err)
+		ulog.Errorf("Sync NAT gateway outgoing state for IP %s error: %+v", pn.VPCIP, err)
 		rollbackReleaseIP()
 		return syncErr
 	}
@@ -261,7 +261,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	// podIP may be deleted in previous CNI DEL action
 	if pn != nil && len(pn.VPCIP) > 0 {
 		ulog.Infof("Pod network info %+v", pn)
-		if err = deleteNATOutgoingIP(pn.VPCIP); err != nil {
+		if err = deleteNATGWOutgoingIP(pn.VPCIP); err != nil {
 			return err
 		}
 		if err = cleanUpIPRoutePolicy(pn.VPCIP); err != nil {

--- a/cmd/cnivpc/nat_outgoing.go
+++ b/cmd/cnivpc/nat_outgoing.go
@@ -26,7 +26,7 @@ import (
 
 // Keep the existing kernel object name: enabling NAT gateway outgoing means
 // node-side NAT outgoing is disabled for the Pod IP.
-const natGWOutgoingEnabledIPSetName = "UCLOUD-NATOUTGOING-OFF"
+const natGWOutgoingEnabledIPSetName = "UCLOUD-NATGW-OUTGOING"
 
 func ensureNATGWOutgoingIPSet() error {
 	err := netlink.IpsetCreate(

--- a/cmd/cnivpc/nat_outgoing.go
+++ b/cmd/cnivpc/nat_outgoing.go
@@ -24,10 +24,7 @@ import (
 	"github.com/vishvananda/netlink/nl"
 )
 
-const (
-	natOutgoingDisabledIPSetName = "UCLOUD-NATOUTGOING-OFF"
-	metadataServiceCIDR          = "100.80.80.80/32"
-)
+const natOutgoingDisabledIPSetName = "UCLOUD-NATOUTGOING-OFF"
 
 func ensureNATOutgoingIPSet() error {
 	err := netlink.IpsetCreate(

--- a/cmd/cnivpc/nat_outgoing.go
+++ b/cmd/cnivpc/nat_outgoing.go
@@ -15,17 +15,24 @@
 package main
 
 import (
+	"context"
 	"net"
 	"syscall"
 
 	"github.com/cockroachdb/errors"
+	"github.com/ucloud/uk8s-cni-vpc/pkg/ipamd"
+	"github.com/ucloud/uk8s-cni-vpc/pkg/kubeclient"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/ulog"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// Keep the existing kernel object name: enabling NAT gateway outgoing means
-// node-side NAT outgoing is disabled for the Pod IP.
+// The set contains Pod IPs whose outbound NAT is handled by the NAT gateway.
 const natGWOutgoingEnabledIPSetName = "UCLOUD-NATGW-OUTGOING"
 
 func ensureNATGWOutgoingIPSet() error {
@@ -51,31 +58,148 @@ func natGWOutgoingIPSetEntry(podIP string) (*netlink.IPSetEntry, error) {
 	return &netlink.IPSetEntry{IP: ip.To4()}, nil
 }
 
-func migrateLegacyNATGWOutgoingIPs() error {
+// migrateLegacyNATGWOutgoingIPs maps persisted Pod IPs to the PodNetworking
+// selected by each live Pod on this node.
+func migrateLegacyNATGWOutgoingIPs(nodeName string) error {
+	if nodeName == "" {
+		return errors.New("main.migrateLegacyNATGWOutgoingIPs missing node name")
+	}
+
 	networks, err := listPodNetworkRecords()
 	if err != nil {
 		return err
 	}
 
+	kubeClient, err := kubeclient.GetNodeClient()
+	if err != nil {
+		return errors.Wrap(err, "main.migrateLegacyNATGWOutgoingIPs get Kubernetes client")
+	}
+	podList, err := kubeClient.CoreV1().Pods(v1.NamespaceAll).List(
+		context.TODO(),
+		metav1.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+		},
+	)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"main.migrateLegacyNATGWOutgoingIPs list Pods on node %s",
+			errors.Safe(nodeName),
+		)
+	}
+	podsByName := make(map[types.NamespacedName]*v1.Pod, len(podList.Items))
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		podsByName[types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}] = pod
+	}
+
+	crdClient, err := kubeclient.GetNodeCRDClient()
+	if err != nil {
+		return errors.Wrap(err, "main.migrateLegacyNATGWOutgoingIPs get CRD client")
+	}
+	podNetworkings, err := crdClient.VpcV1beta1().PodNetworkings().List(
+		context.TODO(),
+		metav1.ListOptions{},
+	)
+	if err != nil {
+		return errors.Wrap(err, "main.migrateLegacyNATGWOutgoingIPs list PodNetworkings")
+	}
+	podNetworkingPolicies := make(map[string]bool, len(podNetworkings.Items))
+	for i := range podNetworkings.Items {
+		podNetworking := &podNetworkings.Items[i]
+		podNetworkingPolicies[podNetworking.Name] = podNetworking.Spec.NATGWOutgoingEnabled
+	}
+
+	// desiredPodIPs is the target ipset state derived from live Pod selections
+	// and the Pod IPs persisted in BoltDB. The disable annotation takes
+	// precedence over both an explicit PodNetworking name and the default one,
+	// matching the CNI ADD path.
+	desiredPodIPs := sets.New[string]()
 	for _, network := range networks {
 		if network == nil {
+			continue
+		}
+
+		pod, exists := podsByName[types.NamespacedName{
+			Namespace: network.PodNS,
+			Name:      network.PodName,
+		}]
+		if !exists {
+			continue
+		}
+		if network.PodUID != "" && network.PodUID != string(pod.UID) {
+			ulog.Warnf(
+				"Ignore stale Pod network record for %s/%s: recorded UID %s, current UID %s",
+				network.PodNS, network.PodName, network.PodUID, pod.UID,
+			)
+			continue
+		}
+		if pod.Annotations[ipamd.AnnotationPodNetworkingDisable] == "true" {
+			continue
+		}
+
+		podNetworkingName := pod.Annotations[ipamd.AnnotationPodNetworkingName]
+		if podNetworkingName == "" {
+			podNetworkingName = DefaultPodNetworkingName
+		}
+		natGWOutgoingEnabled, exists := podNetworkingPolicies[podNetworkingName]
+		if !exists {
+			if podNetworkingName != DefaultPodNetworkingName {
+				return errors.Errorf(
+					"main.migrateLegacyNATGWOutgoingIPs Pod %s/%s references missing PodNetworking %s",
+					errors.Safe(network.PodNS),
+					errors.Safe(network.PodName),
+					errors.Safe(podNetworkingName),
+				)
+			}
+			continue
+		}
+		if !natGWOutgoingEnabled {
 			continue
 		}
 		entry, err := natGWOutgoingIPSetEntry(network.VPCIP)
 		if err != nil {
 			return err
 		}
-		entry.Replace = true
-		if err := netlink.IpsetAdd(natGWOutgoingEnabledIPSetName, entry); err != nil {
-			return errors.Wrapf(
-				err,
-				"main.migrateLegacyNATGWOutgoingIPs add %s",
-				errors.Safe(network.VPCIP),
+		desiredPodIPs.Insert(entry.IP.String())
+	}
+
+	// currentPodIPs is the actual kernel ipset state before migration.
+	currentIPSet, err := netlink.IpsetList(natGWOutgoingEnabledIPSetName)
+	if err != nil {
+		return errors.Wrap(err, "main.migrateLegacyNATGWOutgoingIPs list current ipset")
+	}
+	currentPodIPs := sets.New[string]()
+	for _, entry := range currentIPSet.Entries {
+		ip := entry.IP.To4()
+		if ip == nil {
+			return errors.Errorf(
+				"main.migrateLegacyNATGWOutgoingIPs invalid IPv4 entry %s in current ipset",
+				errors.Safe(entry.IP.String()),
 			)
+		}
+		currentPodIPs.Insert(ip.String())
+	}
+
+	// Add desired members that are missing, then remove current members that
+	// are no longer desired. The two differences fully describe the migration.
+	toAdd := desiredPodIPs.Difference(currentPodIPs)
+	toDelete := currentPodIPs.Difference(desiredPodIPs)
+	for podIP := range toAdd {
+		if _, err := syncNATGWOutgoingIP(podIP, true); err != nil {
+			return err
+		}
+	}
+	for podIP := range toDelete {
+		if err := deleteNATGWOutgoingIP(podIP); err != nil {
+			return err
 		}
 	}
 
-	ulog.Infof("Migrated %d existing Pod IPs to NAT gateway outgoing set", len(networks))
+	ulog.Infof(
+		"Migrated NAT gateway outgoing ipset: desired=%d current=%d add=%d delete=%d",
+		desiredPodIPs.Len(), currentPodIPs.Len(), toAdd.Len(), toDelete.Len(),
+	)
 	return nil
 }
 

--- a/cmd/cnivpc/nat_outgoing.go
+++ b/cmd/cnivpc/nat_outgoing.go
@@ -1,0 +1,132 @@
+// Copyright UCloud. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/cockroachdb/errors"
+	"github.com/ucloud/uk8s-cni-vpc/pkg/ulog"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+)
+
+const (
+	natOutgoingDisabledIPSetName = "UCLOUD-NATOUTGOING-OFF"
+	metadataServiceCIDR          = "100.80.80.80/32"
+)
+
+func ensureNATOutgoingIPSet() error {
+	err := netlink.IpsetCreate(
+		natOutgoingDisabledIPSetName,
+		"hash:ip",
+		netlink.IpsetCreateOptions{Replace: true},
+	)
+	if err != nil {
+		return errors.Wrap(err, "main.ensureNATOutgoingIPSet create")
+	}
+	return nil
+}
+
+func natOutgoingIPSetEntry(podIP string) (*netlink.IPSetEntry, error) {
+	ip := net.ParseIP(podIP)
+	if ip == nil || ip.To4() == nil {
+		return nil, errors.Errorf(
+			"main.natOutgoingIPSetEntry invalid IPv4 address %q",
+			errors.Safe(podIP),
+		)
+	}
+	return &netlink.IPSetEntry{IP: ip.To4()}, nil
+}
+
+func migrateLegacyNATOutgoingIPs() error {
+	networks, err := listPodNetworkRecords()
+	if err != nil {
+		return err
+	}
+
+	for _, network := range networks {
+		if network == nil {
+			continue
+		}
+		entry, err := natOutgoingIPSetEntry(network.VPCIP)
+		if err != nil {
+			return err
+		}
+		entry.Replace = true
+		if err := netlink.IpsetAdd(natOutgoingDisabledIPSetName, entry); err != nil {
+			return errors.Wrapf(
+				err,
+				"main.migrateLegacyNATOutgoingIPs add %s",
+				errors.Safe(network.VPCIP),
+			)
+		}
+	}
+
+	ulog.Infof("Migrated %d existing Pod IPs to NAT outgoing disabled set", len(networks))
+	return nil
+}
+
+// syncNATOutgoingIP converges a Pod IP to the requested NAT outgoing policy.
+// The returned boolean reports whether this call added a new no-NAT member,
+// allowing callers to roll back only their own side effect.
+func syncNATOutgoingIP(podIP string, natOutgoing bool) (bool, error) {
+	if err := ensureNATOutgoingIPSet(); err != nil {
+		return false, err
+	}
+
+	if natOutgoing {
+		if err := deleteNATOutgoingIP(podIP); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	entry, err := natOutgoingIPSetEntry(podIP)
+	if err != nil {
+		return false, err
+	}
+	if err := netlink.IpsetAdd(natOutgoingDisabledIPSetName, entry); err != nil {
+		if errors.Is(err, nl.IPSetError(nl.IPSET_ERR_EXIST)) {
+			return false, nil
+		}
+		return false, errors.Wrapf(
+			err,
+			"main.syncNATOutgoingIP add %s",
+			errors.Safe(podIP),
+		)
+	}
+	return true, nil
+}
+
+func deleteNATOutgoingIP(podIP string) error {
+	entry, err := natOutgoingIPSetEntry(podIP)
+	if err != nil {
+		return err
+	}
+	entry.Replace = true
+	if err := netlink.IpsetDel(natOutgoingDisabledIPSetName, entry); err != nil {
+		if errors.Is(err, syscall.ENOENT) {
+			return nil
+		}
+		return errors.Wrapf(
+			err,
+			"main.deleteNATOutgoingIP delete %s",
+			errors.Safe(podIP),
+		)
+	}
+	return nil
+}

--- a/cmd/cnivpc/nat_outgoing.go
+++ b/cmd/cnivpc/nat_outgoing.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ucloud/uk8s-cni-vpc/pkg/ipamd"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/kubeclient"
 	"github.com/ucloud/uk8s-cni-vpc/pkg/ulog"
+	"github.com/ucloud/uk8s-cni-vpc/rpc"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	v1 "k8s.io/api/core/v1"
@@ -110,10 +111,45 @@ func migrateLegacyNATGWOutgoingIPs(nodeName string) error {
 		podNetworkingPolicies[podNetworking.Name] = podNetworking.Spec.NATGWOutgoingEnabled
 	}
 
-	// desiredPodIPs is the target ipset state derived from live Pod selections
-	// and the Pod IPs persisted in BoltDB. The disable annotation takes
-	// precedence over both an explicit PodNetworking name and the default one,
-	// matching the CNI ADD path.
+	desiredPodIPs := desiredNATGWOutgoingIPs(networks, podsByName, podNetworkingPolicies)
+
+	// currentPodIPs is the actual kernel ipset state before migration.
+	currentIPSet, err := netlink.IpsetList(natGWOutgoingEnabledIPSetName)
+	if err != nil {
+		return errors.Wrap(err, "main.migrateLegacyNATGWOutgoingIPs list current ipset")
+	}
+	currentPodIPs := currentNATGWOutgoingIPs(currentIPSet.Entries)
+
+	// Add desired members that are missing, then remove current members that
+	// are no longer desired. The two differences fully describe the migration.
+	toAdd := desiredPodIPs.Difference(currentPodIPs)
+	toDelete := currentPodIPs.Difference(desiredPodIPs)
+	for podIP := range toAdd {
+		if _, err := syncNATGWOutgoingIP(podIP, true); err != nil {
+			return err
+		}
+	}
+	for podIP := range toDelete {
+		if err := deleteNATGWOutgoingIP(podIP); err != nil {
+			return err
+		}
+	}
+
+	ulog.Infof(
+		"Migrated NAT gateway outgoing ipset: desired=%d current=%d add=%d delete=%d",
+		desiredPodIPs.Len(), currentPodIPs.Len(), toAdd.Len(), toDelete.Len(),
+	)
+	return nil
+}
+
+// desiredNATGWOutgoingIPs derives the target ipset state from live Pod
+// selections and persisted Pod IPs. Invalid individual records are ignored so
+// one stale object cannot prevent the remaining records from converging.
+func desiredNATGWOutgoingIPs(
+	networks []*rpc.PodNetwork,
+	podsByName map[types.NamespacedName]*v1.Pod,
+	podNetworkingPolicies map[string]bool,
+) sets.Set[string] {
 	desiredPodIPs := sets.New[string]()
 	for _, network := range networks {
 		if network == nil {
@@ -145,11 +181,11 @@ func migrateLegacyNATGWOutgoingIPs(nodeName string) error {
 		natGWOutgoingEnabled, exists := podNetworkingPolicies[podNetworkingName]
 		if !exists {
 			if podNetworkingName != DefaultPodNetworkingName {
-				return errors.Errorf(
-					"main.migrateLegacyNATGWOutgoingIPs Pod %s/%s references missing PodNetworking %s",
-					errors.Safe(network.PodNS),
-					errors.Safe(network.PodName),
-					errors.Safe(podNetworkingName),
+				ulog.Warnf(
+					"Ignore Pod network record for %s/%s during NAT gateway outgoing migration: PodNetworking %s does not exist",
+					network.PodNS,
+					network.PodName,
+					podNetworkingName,
 				)
 			}
 			continue
@@ -159,63 +195,48 @@ func migrateLegacyNATGWOutgoingIPs(nodeName string) error {
 		}
 		entry, err := natGWOutgoingIPSetEntry(network.VPCIP)
 		if err != nil {
-			return err
+			ulog.Warnf(
+				"Ignore Pod network record for %s/%s during NAT gateway outgoing migration: %+v",
+				network.PodNS,
+				network.PodName,
+				err,
+			)
+			continue
 		}
 		desiredPodIPs.Insert(entry.IP.String())
 	}
+	return desiredPodIPs
+}
 
-	// currentPodIPs is the actual kernel ipset state before migration.
-	currentIPSet, err := netlink.IpsetList(natGWOutgoingEnabledIPSetName)
-	if err != nil {
-		return errors.Wrap(err, "main.migrateLegacyNATGWOutgoingIPs list current ipset")
-	}
+// currentNATGWOutgoingIPs normalizes the kernel entries used for migration.
+// Entries that cannot participate in this IPv4 ipset are left untouched.
+func currentNATGWOutgoingIPs(entries []netlink.IPSetEntry) sets.Set[string] {
 	currentPodIPs := sets.New[string]()
-	for _, entry := range currentIPSet.Entries {
+	for _, entry := range entries {
 		ip := entry.IP.To4()
 		if ip == nil {
-			return errors.Errorf(
-				"main.migrateLegacyNATGWOutgoingIPs invalid IPv4 entry %s in current ipset",
-				errors.Safe(entry.IP.String()),
+			ulog.Warnf(
+				"Ignore invalid IPv4 entry %s in NAT gateway outgoing ipset during migration",
+				entry.IP.String(),
 			)
+			continue
 		}
 		currentPodIPs.Insert(ip.String())
 	}
-
-	// Add desired members that are missing, then remove current members that
-	// are no longer desired. The two differences fully describe the migration.
-	toAdd := desiredPodIPs.Difference(currentPodIPs)
-	toDelete := currentPodIPs.Difference(desiredPodIPs)
-	for podIP := range toAdd {
-		if _, err := syncNATGWOutgoingIP(podIP, true); err != nil {
-			return err
-		}
-	}
-	for podIP := range toDelete {
-		if err := deleteNATGWOutgoingIP(podIP); err != nil {
-			return err
-		}
-	}
-
-	ulog.Infof(
-		"Migrated NAT gateway outgoing ipset: desired=%d current=%d add=%d delete=%d",
-		desiredPodIPs.Len(), currentPodIPs.Len(), toAdd.Len(), toDelete.Len(),
-	)
-	return nil
+	return currentPodIPs
 }
 
-// syncNATGWOutgoingIP converges a Pod IP to the requested NAT gateway policy.
-// The returned boolean reports whether this call added a new NAT gateway member,
-// allowing callers to roll back only their own side effect.
+// syncNATGWOutgoingIP adds a Pod IP when NAT gateway outgoing is enabled.
+// The disabled path is intentionally a no-op; CNI DEL and initial migration
+// own residual cleanup so disabled Pods do not depend on ipset.
+// The returned boolean lets callers roll back only their own side effect.
 func syncNATGWOutgoingIP(podIP string, natGWOutgoingEnabled bool) (bool, error) {
-	if err := ensureNATGWOutgoingIPSet(); err != nil {
-		return false, err
+	if !natGWOutgoingEnabled {
+		return false, nil
 	}
 
-	if !natGWOutgoingEnabled {
-		if err := deleteNATGWOutgoingIP(podIP); err != nil {
-			return false, err
-		}
-		return false, nil
+	if err := ensureNATGWOutgoingIPSet(); err != nil {
+		return false, err
 	}
 
 	entry, err := natGWOutgoingIPSetEntry(podIP)

--- a/cmd/cnivpc/nat_outgoing.go
+++ b/cmd/cnivpc/nat_outgoing.go
@@ -24,32 +24,34 @@ import (
 	"github.com/vishvananda/netlink/nl"
 )
 
-const natOutgoingDisabledIPSetName = "UCLOUD-NATOUTGOING-OFF"
+// Keep the existing kernel object name: enabling NAT gateway outgoing means
+// node-side NAT outgoing is disabled for the Pod IP.
+const natGWOutgoingEnabledIPSetName = "UCLOUD-NATOUTGOING-OFF"
 
-func ensureNATOutgoingIPSet() error {
+func ensureNATGWOutgoingIPSet() error {
 	err := netlink.IpsetCreate(
-		natOutgoingDisabledIPSetName,
+		natGWOutgoingEnabledIPSetName,
 		"hash:ip",
 		netlink.IpsetCreateOptions{Replace: true},
 	)
 	if err != nil {
-		return errors.Wrap(err, "main.ensureNATOutgoingIPSet create")
+		return errors.Wrap(err, "main.ensureNATGWOutgoingIPSet create")
 	}
 	return nil
 }
 
-func natOutgoingIPSetEntry(podIP string) (*netlink.IPSetEntry, error) {
+func natGWOutgoingIPSetEntry(podIP string) (*netlink.IPSetEntry, error) {
 	ip := net.ParseIP(podIP)
 	if ip == nil || ip.To4() == nil {
 		return nil, errors.Errorf(
-			"main.natOutgoingIPSetEntry invalid IPv4 address %q",
+			"main.natGWOutgoingIPSetEntry invalid IPv4 address %q",
 			errors.Safe(podIP),
 		)
 	}
 	return &netlink.IPSetEntry{IP: ip.To4()}, nil
 }
 
-func migrateLegacyNATOutgoingIPs() error {
+func migrateLegacyNATGWOutgoingIPs() error {
 	networks, err := listPodNetworkRecords()
 	if err != nil {
 		return err
@@ -59,69 +61,69 @@ func migrateLegacyNATOutgoingIPs() error {
 		if network == nil {
 			continue
 		}
-		entry, err := natOutgoingIPSetEntry(network.VPCIP)
+		entry, err := natGWOutgoingIPSetEntry(network.VPCIP)
 		if err != nil {
 			return err
 		}
 		entry.Replace = true
-		if err := netlink.IpsetAdd(natOutgoingDisabledIPSetName, entry); err != nil {
+		if err := netlink.IpsetAdd(natGWOutgoingEnabledIPSetName, entry); err != nil {
 			return errors.Wrapf(
 				err,
-				"main.migrateLegacyNATOutgoingIPs add %s",
+				"main.migrateLegacyNATGWOutgoingIPs add %s",
 				errors.Safe(network.VPCIP),
 			)
 		}
 	}
 
-	ulog.Infof("Migrated %d existing Pod IPs to NAT outgoing disabled set", len(networks))
+	ulog.Infof("Migrated %d existing Pod IPs to NAT gateway outgoing set", len(networks))
 	return nil
 }
 
-// syncNATOutgoingIP converges a Pod IP to the requested NAT outgoing policy.
-// The returned boolean reports whether this call added a new no-NAT member,
+// syncNATGWOutgoingIP converges a Pod IP to the requested NAT gateway policy.
+// The returned boolean reports whether this call added a new NAT gateway member,
 // allowing callers to roll back only their own side effect.
-func syncNATOutgoingIP(podIP string, natOutgoing bool) (bool, error) {
-	if err := ensureNATOutgoingIPSet(); err != nil {
+func syncNATGWOutgoingIP(podIP string, natGWOutgoingEnabled bool) (bool, error) {
+	if err := ensureNATGWOutgoingIPSet(); err != nil {
 		return false, err
 	}
 
-	if natOutgoing {
-		if err := deleteNATOutgoingIP(podIP); err != nil {
+	if !natGWOutgoingEnabled {
+		if err := deleteNATGWOutgoingIP(podIP); err != nil {
 			return false, err
 		}
 		return false, nil
 	}
 
-	entry, err := natOutgoingIPSetEntry(podIP)
+	entry, err := natGWOutgoingIPSetEntry(podIP)
 	if err != nil {
 		return false, err
 	}
-	if err := netlink.IpsetAdd(natOutgoingDisabledIPSetName, entry); err != nil {
+	if err := netlink.IpsetAdd(natGWOutgoingEnabledIPSetName, entry); err != nil {
 		if errors.Is(err, nl.IPSetError(nl.IPSET_ERR_EXIST)) {
 			return false, nil
 		}
 		return false, errors.Wrapf(
 			err,
-			"main.syncNATOutgoingIP add %s",
+			"main.syncNATGWOutgoingIP add %s",
 			errors.Safe(podIP),
 		)
 	}
 	return true, nil
 }
 
-func deleteNATOutgoingIP(podIP string) error {
-	entry, err := natOutgoingIPSetEntry(podIP)
+func deleteNATGWOutgoingIP(podIP string) error {
+	entry, err := natGWOutgoingIPSetEntry(podIP)
 	if err != nil {
 		return err
 	}
 	entry.Replace = true
-	if err := netlink.IpsetDel(natOutgoingDisabledIPSetName, entry); err != nil {
+	if err := netlink.IpsetDel(natGWOutgoingEnabledIPSetName, entry); err != nil {
 		if errors.Is(err, syscall.ENOENT) {
 			return nil
 		}
 		return errors.Wrapf(
 			err,
-			"main.deleteNATOutgoingIP delete %s",
+			"main.deleteNATGWOutgoingIP delete %s",
 			errors.Safe(podIP),
 		)
 	}

--- a/cmd/cnivpc/rpc.go
+++ b/cmd/cnivpc/rpc.go
@@ -64,25 +64,26 @@ func accessToPodNetworkDB(dbName, storageFile string) (database.Database[rpc.Pod
 	return database.NewBolt[rpc.PodNetwork](dbName, db)
 }
 
-func getPodNetworkingConfig(kubeClient *kubernetes.Clientset, podName, podNS string) (*podnetworkingv1beta1.PodNetworking, error) {
+func getPodNetworkingConfig(kubeClient *kubernetes.Clientset, podName, podNS string) (*podnetworkingv1beta1.PodNetworking, string, error) {
 	ability, err := uapi.GetAbility()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get instance ability: %v", err)
+		return nil, "", fmt.Errorf("failed to get instance ability: %v", err)
 	}
 	if !ability.SupportUNI {
 		ulog.Infof("Current uhost does not support UNI, ignore podnetworking config")
-		return nil, nil
+		return nil, "", nil
 	}
 
 	pod, err := kubeClient.CoreV1().Pods(podNS).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pod %s in namespace %s: %v", podName, podNS, err)
+		return nil, "", fmt.Errorf("failed to get pod %s in namespace %s: %v", podName, podNS, err)
 	}
+	nodeName := pod.Spec.NodeName
 	disable := pod.Annotations[ipamd.AnnotationPodNetworkingDisable]
 	if disable == "true" {
 		// User disable podnetworking manually
 		ulog.Infof("pod %s/%s disabled podnetworking", podNS, podName)
-		return nil, nil
+		return nil, nodeName, nil
 	}
 
 	pnName := pod.Annotations[ipamd.AnnotationPodNetworkingName]
@@ -92,22 +93,22 @@ func getPodNetworkingConfig(kubeClient *kubernetes.Clientset, podName, podNS str
 
 	crdClient, err := kubeclient.GetNodeCRDClient()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get crd kube client: %v", err)
+		return nil, "", fmt.Errorf("failed to get crd kube client: %v", err)
 	}
 	podnet, err := crdClient.VpcV1beta1().PodNetworkings().Get(context.TODO(), pnName, metav1.GetOptions{})
 	if err != nil {
 		// 当指定了自定义的 podnetworking 且无法查到时，也要阻塞 pod 创建
 		if k8serr.IsNotFound(err) && pnName == DefaultPodNetworkingName {
-			return nil, nil
+			return nil, nodeName, nil
 		}
-		return nil, fmt.Errorf("failed to get podnetworking with name %s: %v", pnName, err)
+		return nil, "", fmt.Errorf("failed to get podnetworking with name %s: %v", pnName, err)
 	}
 	if len(podnet.Spec.SubnetIds) == 0 {
-		return nil, fmt.Errorf("podnetworking %s has no subnet", pnName)
+		return nil, "", fmt.Errorf("podnetworking %s has no subnet", pnName)
 	}
 
 	if len(podnet.Spec.SecurityGroupIds) == 0 && ability.SecGroup {
-		return nil, errors.New("inconsistency error: node has secgroup but podnetworking config has not")
+		return nil, "", errors.New("inconsistency error: node has secgroup but podnetworking config has not")
 	}
 
 	if len(podnet.Spec.SecurityGroupIds) > 0 && !ability.SecGroup {
@@ -116,7 +117,7 @@ func getPodNetworkingConfig(kubeClient *kubernetes.Clientset, podName, podNS str
 		podnet.Spec.SecurityGroupIds = nil
 	}
 
-	return podnet, nil
+	return podnet, nodeName, nil
 }
 
 type podIPAssignment struct {
@@ -132,7 +133,7 @@ func assignPodIp(podName, podNS, netNS, sandboxId string) (*podIPAssignment, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node kube client: %v", err)
 	}
-	pnConfig, err := getPodNetworkingConfig(kubeClient, podName, podNS)
+	pnConfig, nodeName, err := getPodNetworkingConfig(kubeClient, podName, podNS)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +142,7 @@ func assignPodIp(podName, podNS, netNS, sandboxId string) (*podIPAssignment, err
 	var uni *vpc.NetworkInterface
 	if pnConfig != nil {
 		natGWOutgoingEnabled = pnConfig.Spec.NATGWOutgoingEnabled
-		uni, err = initPodNetworking(pnConfig)
+		uni, err = initPodNetworking(pnConfig, nodeName)
 		if err != nil {
 			return nil, err
 		}
@@ -263,7 +264,7 @@ func allocateSecondaryIP(uni *vpc.NetworkInterface, podName, podNS, sandboxID st
 	return &pn, nil
 }
 
-func initPodNetworking(pnConfig *podnetworkingv1beta1.PodNetworking) (*vpc.NetworkInterface, error) {
+func initPodNetworking(pnConfig *podnetworkingv1beta1.PodNetworking, nodeName string) (*vpc.NetworkInterface, error) {
 	client, err := uapi.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to init uapi client: %v", err)
@@ -298,7 +299,7 @@ func initPodNetworking(pnConfig *podnetworkingv1beta1.PodNetworking) (*vpc.Netwo
 		return nil, err
 	}
 
-	err = iptablesRulesManager.updateRules()
+	err = iptablesRulesManager.updateRules(nodeName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cnivpc/rpc.go
+++ b/cmd/cnivpc/rpc.go
@@ -120,9 +120,9 @@ func getPodNetworkingConfig(kubeClient *kubernetes.Clientset, podName, podNS str
 }
 
 type podIPAssignment struct {
-	network     *rpc.PodNetwork
-	fromIPAMD   bool
-	natOutgoing bool
+	network              *rpc.PodNetwork
+	fromIPAMD            bool
+	natGWOutgoingEnabled bool
 }
 
 // If there is ipamd daemon service, use ipamd to allocate Pod Ip;
@@ -137,10 +137,10 @@ func assignPodIp(podName, podNS, netNS, sandboxId string) (*podIPAssignment, err
 		return nil, err
 	}
 
-	natOutgoing := true
+	var natGWOutgoingEnabled bool
 	var uni *vpc.NetworkInterface
 	if pnConfig != nil {
-		natOutgoing = pnConfig.Spec.NATOutgoingEnabled()
+		natGWOutgoingEnabled = pnConfig.Spec.NATGWOutgoingEnabled
 		uni, err = initPodNetworking(pnConfig)
 		if err != nil {
 			return nil, err
@@ -161,7 +161,11 @@ func assignPodIp(podName, podNS, netNS, sandboxId string) (*podIPAssignment, err
 			if err != nil {
 				return nil, fmt.Errorf("failed to call ipamd: %v", err)
 			}
-			return &podIPAssignment{network: ip, fromIPAMD: true, natOutgoing: natOutgoing}, nil
+			return &podIPAssignment{
+				network:              ip,
+				fromIPAMD:            true,
+				natGWOutgoingEnabled: natGWOutgoingEnabled,
+			}, nil
 		}
 	}
 
@@ -179,7 +183,10 @@ func assignPodIp(podName, podNS, netNS, sandboxId string) (*podIPAssignment, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup secondary ip: %v", err)
 	}
-	return &podIPAssignment{network: ip, natOutgoing: natOutgoing}, nil
+	return &podIPAssignment{
+		network:              ip,
+		natGWOutgoingEnabled: natGWOutgoingEnabled,
+	}, nil
 }
 
 // If there is ipamd daemon service, use ipamd to release Pod Ip;

--- a/cmd/cnivpc/rpc.go
+++ b/cmd/cnivpc/rpc.go
@@ -299,7 +299,7 @@ func initPodNetworking(pnConfig *podnetworkingv1beta1.PodNetworking, nodeName st
 		return nil, err
 	}
 
-	err = iptablesRulesManager.updateRules(nodeName)
+	err = iptablesRulesManager.updateRules(nodeName, pnConfig.Spec.NATGWOutgoingEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cnivpc/rpc.go
+++ b/cmd/cnivpc/rpc.go
@@ -16,12 +16,12 @@ package main
 import (
 	"cmp"
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/ucloud/ucloud-sdk-go/services/vpc"
 	"github.com/ucloud/ucloud-sdk-go/ucloud"
 	"github.com/ucloud/ucloud-sdk-go/ucloud/request"
@@ -119,24 +119,31 @@ func getPodNetworkingConfig(kubeClient *kubernetes.Clientset, podName, podNS str
 	return podnet, nil
 }
 
+type podIPAssignment struct {
+	network     *rpc.PodNetwork
+	fromIPAMD   bool
+	natOutgoing bool
+}
 
 // If there is ipamd daemon service, use ipamd to allocate Pod Ip;
 // if not, do this on myself.
-func assignPodIp(podName, podNS, netNS, sandboxId string) (*rpc.PodNetwork, bool, error) {
+func assignPodIp(podName, podNS, netNS, sandboxId string) (*podIPAssignment, error) {
 	kubeClient, err := kubeclient.GetNodeClient()
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to get node kube client: %v", err)
+		return nil, fmt.Errorf("failed to get node kube client: %v", err)
 	}
 	pnConfig, err := getPodNetworkingConfig(kubeClient, podName, podNS)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
+	natOutgoing := true
 	var uni *vpc.NetworkInterface
 	if pnConfig != nil {
+		natOutgoing = pnConfig.Spec.NATOutgoingEnabled()
 		uni, err = initPodNetworking(pnConfig)
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 	}
 
@@ -152,27 +159,27 @@ func assignPodIp(podName, podNS, netNS, sandboxId string) (*rpc.PodNetwork, bool
 		if enabledIpamd(c) && ipamdSupportMultiSubnet(c) {
 			ip, err := allocateSecondaryIPFromIpamd(c, uni, podName, podNS, netNS, sandboxId)
 			if err != nil {
-				return nil, false, fmt.Errorf("failed to call ipamd: %v", err)
+				return nil, fmt.Errorf("failed to call ipamd: %v", err)
 			}
-			return ip, true, nil
+			return &podIPAssignment{network: ip, fromIPAMD: true, natOutgoing: natOutgoing}, nil
 		}
 	}
 
 	enableStaticIP, _, err := ipamd.IsPodEnableStaticIP(kubeClient, podName, podNS)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to check pod static ip enable: %v", err)
+		return nil, fmt.Errorf("failed to check pod static ip enable: %v", err)
 	}
 	if enableStaticIP {
 		// If pod enable static ip, we donot allow it to allocate ip without ipamd
-		return nil, false, fmt.Errorf("pod %s/%s enable static ip, but ipamd is not enabled", podNS, podName)
+		return nil, fmt.Errorf("pod %s/%s enable static ip, but ipamd is not enabled", podNS, podName)
 	}
 
 	// ipamd not available, directly call vpc to allocate IP
 	ip, err := allocateSecondaryIP(uni, podName, podNS, sandboxId)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to setup secondary ip: %v", err)
+		return nil, fmt.Errorf("failed to setup secondary ip: %v", err)
 	}
-	return ip, false, nil
+	return &podIPAssignment{network: ip, natOutgoing: natOutgoing}, nil
 }
 
 // If there is ipamd daemon service, use ipamd to release Pod Ip;
@@ -791,6 +798,42 @@ func delPodNetworkRecordFromIpamd(c rpc.CNIIpamClient, podName, podNS, sandBoxID
 		return fmt.Errorf("gRPC DelPodNetworkRecord failed, code %v", r.Code)
 	}
 	return nil
+}
+
+func listPodNetworkRecords() ([]*rpc.PodNetwork, error) {
+	conn, err := grpc.Dial(IpamdServiceSocket,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err == nil {
+		defer conn.Close()
+		client := rpc.NewCNIIpamClient(conn)
+		if enabledIpamd(client) {
+			response, err := client.ListPodNetworkRecord(
+				context.Background(),
+				&rpc.ListPodNetworkRecordRequest{},
+			)
+			if err != nil {
+				return nil, errors.Wrap(err, "main.listPodNetworkRecords list from ipamd")
+			}
+			if response.Code != rpc.CNIErrorCode_CNISuccess {
+				return nil, errors.Errorf(
+					"main.listPodNetworkRecords ipamd returned code %d",
+					errors.Safe(response.Code),
+				)
+			}
+			return response.Networks, nil
+		}
+	}
+
+	db, err := accessToPodNetworkDB(CNIVpcDbName, storageFile)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	records, err := db.List()
+	if err != nil {
+		return nil, errors.Wrap(err, "main.listPodNetworkRecords list local database")
+	}
+	return database.Values(records), nil
 }
 
 // If there is ipamd daemon service, use ipamd to get PodNetworkRecord;

--- a/deploy/podnetworking.yaml
+++ b/deploy/podnetworking.yaml
@@ -33,9 +33,9 @@ spec:
                   enum:
                     - sequential
                     - balanced
-                natOutgoing:
+                natGWOutgoingEnabled:
                   type: boolean
-                  default: true
+                  default: false
             status:
               type: object
               properties:

--- a/deploy/podnetworking.yaml
+++ b/deploy/podnetworking.yaml
@@ -33,6 +33,9 @@ spec:
                   enum:
                     - sequential
                     - balanced
+                natOutgoing:
+                  type: boolean
+                  default: true
             status:
               type: object
               properties:

--- a/kubernetes/apis/podnetworking/v1beta1/types.go
+++ b/kubernetes/apis/podnetworking/v1beta1/types.go
@@ -46,13 +46,9 @@ type PodNetworkingSpec struct {
 	SecurityGroupIds []string                 `json:"securityGroupIds"`
 	SubnetIds        []string                 `json:"subnetIds"`
 	Strategy         SubnetAllocationStrategy `json:"strategy,omitempty"`
-	NATOutgoing      *bool                    `json:"natOutgoing,omitempty"`
-}
-
-// NATOutgoingEnabled returns whether traffic leaving the VPC should be
-// masqueraded. NAT is enabled by default for backward compatibility.
-func (in PodNetworkingSpec) NATOutgoingEnabled() bool {
-	return in.NATOutgoing == nil || *in.NATOutgoing
+	// NATGWOutgoingEnabled indicates that outbound NAT is handled by the NAT gateway
+	// instead of the node.
+	NATGWOutgoingEnabled bool `json:"natGWOutgoingEnabled,omitempty"`
 }
 
 // PodNetworkingSpec is the status for PodNetworking resource

--- a/kubernetes/apis/podnetworking/v1beta1/types.go
+++ b/kubernetes/apis/podnetworking/v1beta1/types.go
@@ -46,6 +46,13 @@ type PodNetworkingSpec struct {
 	SecurityGroupIds []string                 `json:"securityGroupIds"`
 	SubnetIds        []string                 `json:"subnetIds"`
 	Strategy         SubnetAllocationStrategy `json:"strategy,omitempty"`
+	NATOutgoing      *bool                    `json:"natOutgoing,omitempty"`
+}
+
+// NATOutgoingEnabled returns whether traffic leaving the VPC should be
+// masqueraded. NAT is enabled by default for backward compatibility.
+func (in PodNetworkingSpec) NATOutgoingEnabled() bool {
+	return in.NATOutgoing == nil || *in.NATOutgoing
 }
 
 // PodNetworkingSpec is the status for PodNetworking resource

--- a/kubernetes/apis/podnetworking/v1beta1/zz_generated.deepcopy.go
+++ b/kubernetes/apis/podnetworking/v1beta1/zz_generated.deepcopy.go
@@ -96,11 +96,6 @@ func (in *PodNetworkingSpec) DeepCopyInto(out *PodNetworkingSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.NATOutgoing != nil {
-		in, out := &in.NATOutgoing, &out.NATOutgoing
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 

--- a/kubernetes/apis/podnetworking/v1beta1/zz_generated.deepcopy.go
+++ b/kubernetes/apis/podnetworking/v1beta1/zz_generated.deepcopy.go
@@ -96,6 +96,11 @@ func (in *PodNetworkingSpec) DeepCopyInto(out *PodNetworkingSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NATOutgoing != nil {
+		in, out := &in.NATOutgoing, &out.NATOutgoing
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
## 开发内容

- 为 `PodNetworking` 新增 `natOutgoing` 配置，默认开启以兼容现有行为。
- 使用 ipset 记录禁用 NAT Outgoing 的 Pod IP，并在 CNI ADD/DEL 时同步和清理。
- 新增 iptables bypass 规则，使 `natOutgoing: false` 的 Pod 不设置 connmark，经 UNI 保留源 IP 出站。